### PR TITLE
Print output for schemas using 'in' but no 'schema'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,9 @@ const outputSchemas = (apiDocument: ApiDocument, schemas: unknown): string => {
     });
   } else {
     output += "```ts\n";
-    if ("in" in apiObject) {
+    if ("in" in apiObject && !("schema" in apiObject)) {
+      output += JSON.stringify(apiObject, undefined, "  ") + "\n";
+    } else if ("in" in apiObject) {
       output += outputRefComment(schemas, 0);
       output += outputObject(
         apiDocument,


### PR DESCRIPTION
As `apiKey` spec uses the `in` key but not `schema` it was not printing any output

```md
### #/components/securitySchemes/ApiKeyAuth

```ts
``
```


Anything that uses `in` but no `schema` will now print raw json
```yml
components
  securitySchemes:
    ApiKeyAuth:
      type: apiKey
      in: header
      name: X-API-KEY
```
prints
```
### #/components/securitySchemes/ApiKeyAuth

```ts
{
  "type": "apiKey",
  "in": "header",
  "name": "X-API-KEY"
}
``
```