### PR TITLE
feat: use more compatible markdown code name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ const outputSchemas = (apiDocument: ApiDocument, schemas: unknown): string => {
       output += outputSchemas(apiDocument, value.schema);
     });
   } else {
-    output += "```ts\n";
+    output += "```typescript\n";
     if ("schema" in apiObject) {
       output += outputRefComment(schemas, 0);
       output += outputObject(


### PR DESCRIPTION
The code name in openapi-to-md is ```ts``` , which is not recognized by some editors.  Using ```typescript``` is more compatible.